### PR TITLE
fix bug where file uploading fails on the forum page

### DIFF
--- a/lib/redmine_dropbox/attachments_controller_patch.rb
+++ b/lib/redmine_dropbox/attachments_controller_patch.rb
@@ -64,11 +64,18 @@ module RedmineDropbox
           # For attachments in the "File" area, we want to identify
           # as a "Project" since there technically is no "File" container
           klass = "Project" if klass == "File"
+          # For attachments in the "Topic" (Forum) area, we want to identify
+          # as a "Message" since there technically is no "Topic" container
+          klass = "Message" if klass == "Topic"
 
           # Try to match an id (regardless of whether it'll be valid)
           record  = ref[-1].to_i
           project = if record > 0
-            klass.constantize.find(record).project_id
+            if klass == "Message"
+              klass.constantize.find(record).project.id # Message does not have the member: project_id
+            else
+              klass.constantize.find(record).project_id
+            end
           else
             ref[0] # we won't have a project AND a record, so this shouldn't fail
           end


### PR DESCRIPTION
(sometimes?) ajax file uploading fails on the forum page.

I found that the error is raised when the HTTP_REFERER header indicates a forum-message page e.g. `https://redmine.example.com/boards/1/topics/2`, in which case, `NameError` (uninitialized constant Topic) was raised at https://github.com/cat-in-136/redmine_dropbox_attachments/blame/b337d5ff64fa5af285103903b0a166c58a751c26/lib/redmine_dropbox/attachments_controller_patch.rb#L73

To fix this issue, this PR introduce a dirty HACK of special handling for forum-message pages.