### PR TITLE
Cache the temporary links to attachment on dropbox

### DIFF
--- a/lib/redmine_dropbox/attachments_controller_patch.rb
+++ b/lib/redmine_dropbox/attachments_controller_patch.rb
@@ -31,11 +31,13 @@ module RedmineDropbox
 
         # XXX redmine_dropbox_attachments 1.x compatibility
         # if the file doesn't existing in the /base/project/class/filename location, try falling back to /base/filename
-        ref = begin
-          client.get_temporary_link(path)
-        rescue DropboxApi::Errors::NotFoundError
-          p = path.split("/")
-          client.get_temporary_link([p[0], p[-1]].flatten.join("/"))
+        ref = Rails.cache.fetch("redmine_dropbox_attachments/#{URI.encode_www_form_component(path)}/temporary_link", expires_in: 2.hours) do
+          begin
+            client.get_temporary_link(path)
+          rescue DropboxApi::Errors::NotFoundError
+            p = path.split("/")
+            client.get_temporary_link([p[0], p[-1]].flatten.join("/"))
+          end
         end
 
         redirect_to ref.link


### PR DESCRIPTION
The plugin ask dropbox to create a temporary link for each request. This behavior may waste communication charges. Because different temporary link disables caching mechanism.

* Generated temporary link will be expire in four hours as written in https://www.dropbox.com/developers/documentation/http/documentation#files-get_temporary_link
* Dropbox returns the response with `Cache-Control: max-age=0`. But if it is re-request, they returns `304 Not Modified`.
* If the same temporary link is returned, transmission between the client browser and Dropbox would be minimized.

To return the same temporary link is returned (during 2 hours), this PR introduces caching of the temporary link.